### PR TITLE
Update titlepage with more accurate terminology

### DIFF
--- a/bachproef/hogent-thesis-titlepage.sty
+++ b/bachproef/hogent-thesis-titlepage.sty
@@ -59,11 +59,11 @@
     \begin{center}
       \begingroup
       \rmfamily
-      \IfLanguageName{dutch}{Faculteit Bedrijf en Organisatie}{Faculty of Business and Information Management}\\[3cm]
+      \IfLanguageName{dutch}{Departement IT en Digitale Innovatie}{Department IT and Digital Innovation}\\[3cm]
       \@title
       \vfill
       \@author\\[3.5cm]
-      \IfLanguageName{dutch}{Scriptie voorgedragen tot het bekomen van de graad van\\professionele bachelor in de toegepaste informatica}{Thesis submitted in partial fulfilment of the requirements for the degree of\\professional bachelor of applied computer science}\\[2cm]
+      \IfLanguageName{dutch}{Scriptie voorgedragen tot het bekomen van de graad van\\professionele bachelor in de toegepaste informatica}{Thesis submitted in partial fulfilment of the requirements for the degree of\\professional bachelor of applied information technology}\\[2cm]
       Promotor:\\
       \@promotor\\
       \ifdefempty{\@copromotor}{\vspace{2.5cm}}{Co-promotor:\\\@copromotor\\[2.5cm]}


### PR DESCRIPTION
1. Faculty became Department:
    - Faculteit Bedrijf en Organisatie -> Departement IT en Digitale Innovatie
    - Faculty of Business and Information Management -> Department IT and Digital Innovation

2. "Applied Information Technology" is the official name of the degree in English


Additional thoughts: "Toegepaste Informatica" and "Applied Information Technology" should be capitalized (?)