### PR TITLE
Fix artifacts action permissions

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -8,6 +8,9 @@ on:
     # Every day at 1am
     - cron: '0 1 * * *'
 
+permissions:
+  actions: write
+
 jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Deze PR zorgt ervoor dat deze workflow correct kan runnen in nieuwe repositories.

De action in deze workflow heeft de `actions:write` permission nodig, aangezien het [deze API endpoint](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#delete-an-artifact) aanspreekt.  In deze repository is het ingesteld dat actions by default read en write access hebben, en die instelling wordt ook overgenomen bij forks, maar bij een eigen reupload van de repository (zoals aangeraden voor studenten in de README) gebeurt dit niet. Dit zorgt ervoor dat deze action elke nacht zal falen voor elke student, tenzij ze de default actions permissions aanpassen in hun repository.

Hier heb ik de nodige permission toegevoegd aan de workflow zelf, zodat deze kan blijven werken ongeacht de repository settings, en dat studenten zelf geen verdere aanpassing moeten maken.