### PR TITLE
Fix typo in output path of VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "latex-workshop.latex.outDir": "output",
+  "latex-workshop.latex.outDir": "../output",
   "latex-workshop.latex.recipes": [
         {
             "name": "xelatex× 2",


### PR DESCRIPTION
There was a mismatch in the output path of the GitHub action and the local setup, now they're identical.