### PR TITLE
Quotes toegevoegd aan .bat files

### DIFF
--- a/make_poster.bat
+++ b/make_poster.bat
@@ -4,7 +4,7 @@
 docker build -t bpimg -f docker/Dockerfile .
 
 @REM build the proposal
-docker run --rm -v %cd%:/bp bpimg sh /bp/docker/render_thesis.sh poster
+docker run --rm -v "%cd%:/bp" bpimg sh /bp/docker/render_thesis.sh poster
 
 @REM keep window open after run
 pause

--- a/make_thesis.bat
+++ b/make_thesis.bat
@@ -4,7 +4,7 @@
 docker build -t bpimg -f docker/Dockerfile .
 
 @REM build the proposal
-docker run --rm -v %cd%:/bp bpimg sh /bp/docker/render_thesis.sh bachproef
+docker run --rm -v "%cd%:/bp" bpimg sh /bp/docker/render_thesis.sh bachproef
 
 @REM keep window open after run
 pause

--- a/make_voorstel.bat
+++ b/make_voorstel.bat
@@ -4,7 +4,7 @@
 docker build -t bpimg -f docker/Dockerfile .
 
 @REM build the proposal
-docker run --rm -v %cd%:/bp bpimg sh /bp/docker/render_thesis.sh voorstel
+docker run --rm -v "%cd%:/bp" bpimg sh /bp/docker/render_thesis.sh voorstel
 
 @REM keep window open after run
 pause


### PR DESCRIPTION
Op Windows, zonder deze quotes, als er een spatie in het padnaam zit, krijg je volgende error:

```
Unable to find image 'dev:latest' locally
docker: Error response from daemon: pull access denied for dev, repository does not exist or may require 'docker login'.
See 'docker run --help'.
```

Door de quotes toe te voegen kan deze foutmelding verholpen worden en kan de bachelorproef alsnog gecompileerd worden